### PR TITLE
Fixed incorrect normalization

### DIFF
--- a/src/transformers/image_processing_utils_fast.py
+++ b/src/transformers/image_processing_utils_fast.py
@@ -304,9 +304,9 @@ class BaseImageProcessorFast(BaseImageProcessor):
         A wrapper around `F.resize` so that it is compatible with torch.compile when the image is a uint8 tensor.
         """
         if image.dtype == torch.uint8:
-            image = image.float() / 256
+            image = image.float() / 255
             image = F.resize(image, new_size, interpolation=interpolation, antialias=antialias)
-            image = image * 256
+            image = image * 255
             image = torch.where(image > 255, 255, image)
             image = torch.where(image < 0, 0, image)
             image = image.round().to(torch.uint8)


### PR DESCRIPTION
I've notices a possible typo in [`src/transformers/image_processing_utils_fast.py#compile_friendly_resize`](https://github.com/huggingface/transformers/blob/c81723d31b8a532803feee2bbce66e4f03829759/src/transformers/image_processing_utils_fast.py#L307) for uin8 the normalization is done slightly off with 256 instead of 255, which only still works because its done consistenly (its normalized and denormalized teh same way) incorrect.

[`image = image.float() / 256`](https://github.com/huggingface/transformers/blob/c81723d31b8a532803feee2bbce66e4f03829759/src/transformers/image_processing_utils_fast.py#L307)
[`image = image * 256`](https://github.com/huggingface/transformers/blob/c81723d31b8a532803feee2bbce66e4f03829759/src/transformers/image_processing_utils_fast.py#L309C13-L309C32)


The exaplanation is simple:

`255` (the max value for a `uint8`) should map to `1.` but it doesn't with teh only implementation